### PR TITLE
common: tdx-info: Detect devicetree checking for /proc/device-tree/model

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ Usage: ./tdx-info [OPTION]
 
 For older versions of BSP or TorizonCore (versions 5 and older), run the following command to print the information:
 wget https://raw.githubusercontent.com/toradex/tdx-info/master/tdx-info --output-document=tdx-info && sudo sh ./tdx-info
+
+If the `JSON_OUTPUT` environment variable is set, the script will output in JSON format.

--- a/tdx-info
+++ b/tdx-info
@@ -21,7 +21,11 @@ print_header ()
         exit 1
     fi
     if [ ! -z "$JSON_OUTPUT" ] ; then
+        if [ -n "$INSIDE_OBJECT" ] ; then
+            printf ",\n"
+        fi
         echo "  \"$(slugify $1)\": {"
+        INSIDE_OBJECT=1
         return
     fi
     if [ -n "$1" ]; then
@@ -59,14 +63,20 @@ print_info_json ()
         echo 'Error: "print_info" is missing parameter(s)!'
         exit 1
     fi
-    #                                               escape \ (\ -> \\)     escape " (" -> \")         newline -> \n 
-    echo "    \"$(slugify "$1")\": \"$(echo "$2" | sed "s/['\\]/\\\&/g" | sed "s/['\"]/\\\&/g" | awk '{printf "%s\\n", $0}')\","
+    if [ -n "$INSIDE_OBJECT_2" ] ; then
+        printf ",\n"
+    fi
+    INSIDE_OBJECT_2=1
+
+    #                                                escape \ (\ -> \\)     escape " (" -> \")         newline -> \n 
+    echo -n "    \"$(slugify "$1")\": \"$(echo "$2" | sed "s/['\\]/\\\&/g" | sed "s/['\"]/\\\&/g" | awk '{printf "%s\\n", $0}')\""
 }
 
 print_footer ()
 {
     if [ ! -z "$JSON_OUTPUT" ] ; then
-        echo "  },"
+        printf "  }"
+        unset INSIDE_OBJECT_2
         return
     fi
 

--- a/tdx-info
+++ b/tdx-info
@@ -111,10 +111,23 @@ software_summary ()
 
 hardware_info ()
 {
-    hw_model=$(tr -d '\0' 2> /dev/null </proc/device-tree/model)
-    serial=$(tr -d '\0' 2> /dev/null </proc/device-tree/serial-number)
-    som_pid4=$(tr -d '\0' 2> /dev/null </proc/device-tree/toradex,product-id)
-    som_pid8=$(tr -d '\0' 2> /dev/null </proc/device-tree/toradex,board-rev)
+    if [ "$USE_DEVICETREE" ]; then
+        hw_model=$(tr -d '\0' 2> /dev/null </proc/device-tree/model)
+        serial=$(tr -d '\0' 2> /dev/null </proc/device-tree/serial-number)
+        som_pid4=$(tr -d '\0' 2> /dev/null </proc/device-tree/toradex,product-id)
+        som_pid8=$(tr -d '\0' 2> /dev/null </proc/device-tree/toradex,board-rev)
+    else
+        # so, possible we can get the data from bios
+        _product_name=$(cat /sys/devices/virtual/dmi/id/board_name)
+        _product_vendor=$(cat /sys/devices/virtual/dmi/id/board_vendor)
+        _product_version=$(cat /sys/devices/virtual/dmi/id/board_version)
+
+        hw_model="$_product_vendor $_product_name $_product_version"
+        serial=$(cat /sys/devices/virtual/dmi/id/board_serial)
+        som_pid4=""
+        som_pid8=""
+    fi
+
     processor=$(uname -m)
 
     print_header "Hardware info"

--- a/tdx-info
+++ b/tdx-info
@@ -350,6 +350,5 @@ else
     hardware_info
 fi
 if [ ! -z "$JSON_OUTPUT" ] ; then
-    echo "}"
+    printf "\n}\n"
 fi
-

--- a/tdx-info
+++ b/tdx-info
@@ -52,6 +52,7 @@ software_summary ()
     if [ -f /etc/os-release ]; then
         distro_name=$(grep ^NAME /etc/os-release)
         distro_version=$(grep VERSION_ID /etc/os-release)
+        distro_variant=$(grep VARIANT /etc/os-release)
     else
         distro_name=$(cat /etc/issue)
         distro_version=""
@@ -64,6 +65,7 @@ software_summary ()
     print_info "Kernel command line" "$kernel_cmdline"
     print_info "Distro name" "$distro_name"
     print_info "Distro version" "$distro_version"
+    print_info "Distro variant" "$distro_variant"
     print_info "Hostname" "$hostname"
     print_footer
 }

--- a/tdx-info
+++ b/tdx-info
@@ -210,7 +210,8 @@ devicetree_detect ()
     # GRUB seem to have some sort of support for device tree
     if  find /boot/ -name "*dtb" 2> /dev/null | grep -q . || \
         find /var/rootdirs/mnt/boot/ -name "*dtb" 2> /dev/null | grep -q . || \
-        find /dev/ -iname "*ubi*" 2> /dev/null | grep -q .; then
+        find /dev/ -iname "*ubi*" 2> /dev/null | grep -q . || \
+        find /proc/device-tree/ -name "model" 2> /dev/null | grep -q .; then
         export USE_DEVICETREE=1
     else
         export USE_DEVICETREE=""

--- a/tdx-info
+++ b/tdx-info
@@ -9,21 +9,35 @@ TABULATION_WIDTH=25
 
 #### Functions ####
 
+slugify ()
+{
+    echo "$1" | sed -r s/[^a-zA-Z0-9]+/-/g | sed -r s/^-+\|-+$//g | tr A-Z a-z
+}
+
 print_header ()
 {
+    if [ -z "$1" ] ; then
+        echo 'Error: "print_info" is missing parameter(s)!'
+        exit 1
+    fi
+    if [ ! -z "$JSON_OUTPUT" ] ; then
+        echo "  \"$(slugify $1)\": {"
+        return
+    fi
     if [ -n "$1" ]; then
         echo ""
         echo "$1"
         printf "%0.s-" $(seq 1 $HORIZONTAL_LINE_WIDTH)
         printf "\n"
-    else
-        echo 'Error: "print_header" called without a parameter!'
-        exit 1
     fi
 }
 
 print_info ()
 {
+    if [ ! -z "$JSON_OUTPUT" ] ; then
+        print_info_json "$1" "$2"
+        return
+    fi
     if [ -z "$1" ] ; then
         echo 'Error: "print_info" is missing parameter(s)!'
         exit 1
@@ -39,8 +53,23 @@ print_info ()
     fi
 }
 
+print_info_json ()
+{
+    if [ -z "$1" ] ; then
+        echo 'Error: "print_info" is missing parameter(s)!'
+        exit 1
+    fi
+    #                                               escape \ (\ -> \\)     escape " (" -> \")         newline -> \n 
+    echo "    \"$(slugify "$1")\": \"$(echo "$2" | sed "s/['\\]/\\\&/g" | sed "s/['\"]/\\\&/g" | awk '{printf "%s\\n", $0}')\","
+}
+
 print_footer ()
 {
+    if [ ! -z "$JSON_OUTPUT" ] ; then
+        echo "  },"
+        return
+    fi
+
     printf "%0.s-" $(seq 1 $HORIZONTAL_LINE_WIDTH)
     printf "\n"
 }
@@ -256,6 +285,11 @@ check_root_user
 distro_detect
 devicetree_detect
 bootloader_detect
+if [ ! -z "$JSON_OUTPUT" ] ; then
+    echo "{"
+fi
+
+
 
 if [ $# -ne 0 ]; then
 
@@ -305,3 +339,7 @@ else
     software_summary
     hardware_info
 fi
+if [ ! -z "$JSON_OUTPUT" ] ; then
+    echo "}"
+fi
+

--- a/tdx-info
+++ b/tdx-info
@@ -24,7 +24,7 @@ print_header ()
         if [ -n "$INSIDE_OBJECT" ] ; then
             printf ",\n"
         fi
-        echo "  \"$(slugify $1)\": {"
+        echo "  \"$(slugify "$1")\": {"
         INSIDE_OBJECT=1
         return
     fi
@@ -68,8 +68,8 @@ print_info_json ()
     fi
     INSIDE_OBJECT_2=1
 
-    #                                                escape \ (\ -> \\)     escape " (" -> \")         newline -> \n 
-    echo -n "    \"$(slugify "$1")\": \"$(echo "$2" | sed "s/['\\]/\\\&/g" | sed "s/['\"]/\\\&/g" | awk '{printf "%s\\n", $0}')\""
+    #                                                          \ -> \\)              " -> \"               newline -> \n
+    echo -n "    \"$(slugify "$1")\": \"$(echo -n "$2" | sed "s/['\\]/\\\&/g" | sed "s/['\"]/\\\&/g" | sed ':a;N;$!ba;s/\n/\\n/g')\""
 }
 
 print_footer ()


### PR DESCRIPTION
When using Common Torizon on Raspberry Pi 4 the methods used to detect the use of devicetree are not enough. So, this patch adds a new method to detect the use of devicetree checking for the existance of /proc/device-tree/model that should be default on all devicetree enabled systems.