### PR TITLE
common: tdx-info: Add distro variant to software summary

### DIFF
--- a/tdx-info
+++ b/tdx-info
@@ -52,6 +52,7 @@ software_summary ()
     if [ -f /etc/os-release ]; then
         distro_name=$(grep ^NAME /etc/os-release)
         distro_version=$(grep VERSION_ID /etc/os-release)
+        distro_variant=$(grep VARIANT /etc/os-release)
     else
         distro_name=$(cat /etc/issue)
         distro_version=""
@@ -64,6 +65,7 @@ software_summary ()
     print_info "Kernel command line" "$kernel_cmdline"
     print_info "Distro name" "$distro_name"
     print_info "Distro version" "$distro_version"
+    print_info "Distro variant" "$distro_variant"
     print_info "Hostname" "$hostname"
     print_footer
 }


### PR DESCRIPTION
Show the value of the VARIANT field from /etc/os-release in the software summary. This is useful to identify the variant of a distro, like "Docker" or "Podman".