### PR TITLE
Add an option to output JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ Usage: ./tdx-info [OPTION]
 
 For older versions of BSP or TorizonCore (versions 5 and older), run the following command to print the information:
 wget https://raw.githubusercontent.com/toradex/tdx-info/master/tdx-info --output-document=tdx-info && sudo sh ./tdx-info
+
+If the `JSON_OUTPUT` environment variable is set, the script will output in JSON format.

--- a/tdx-info
+++ b/tdx-info
@@ -21,7 +21,11 @@ print_header ()
         exit 1
     fi
     if [ ! -z "$JSON_OUTPUT" ] ; then
+        if [ -n "$INSIDE_OBJECT" ] ; then
+            printf ",\n"
+        fi
         echo "  \"$(slugify $1)\": {"
+        INSIDE_OBJECT=1
         return
     fi
     if [ -n "$1" ]; then
@@ -59,14 +63,20 @@ print_info_json ()
         echo 'Error: "print_info" is missing parameter(s)!'
         exit 1
     fi
-    #                                               escape \ (\ -> \\)     escape " (" -> \")         newline -> \n 
-    echo "    \"$(slugify "$1")\": \"$(echo "$2" | sed "s/['\\]/\\\&/g" | sed "s/['\"]/\\\&/g" | awk '{printf "%s\\n", $0}')\","
+    if [ -n "$INSIDE_OBJECT_2" ] ; then
+        printf ",\n"
+    fi
+    INSIDE_OBJECT_2=1
+
+    #                                                escape \ (\ -> \\)     escape " (" -> \")         newline -> \n 
+    echo -n "    \"$(slugify "$1")\": \"$(echo "$2" | sed "s/['\\]/\\\&/g" | sed "s/['\"]/\\\&/g" | awk '{printf "%s\\n", $0}')\""
 }
 
 print_footer ()
 {
     if [ ! -z "$JSON_OUTPUT" ] ; then
-        echo "  },"
+        printf "  }"
+        unset INSIDE_OBJECT_2
         return
     fi
 

--- a/tdx-info
+++ b/tdx-info
@@ -9,21 +9,35 @@ TABULATION_WIDTH=25
 
 #### Functions ####
 
+slugify ()
+{
+    echo "$1" | sed -r s/[^a-zA-Z0-9]+/-/g | sed -r s/^-+\|-+$//g | tr A-Z a-z
+}
+
 print_header ()
 {
+    if [ -z "$1" ] ; then
+        echo 'Error: "print_info" is missing parameter(s)!'
+        exit 1
+    fi
+    if [ ! -z "$JSON_OUTPUT" ] ; then
+        echo "  \"$(slugify $1)\": {"
+        return
+    fi
     if [ -n "$1" ]; then
         echo ""
         echo "$1"
         printf "%0.s-" $(seq 1 $HORIZONTAL_LINE_WIDTH)
         printf "\n"
-    else
-        echo 'Error: "print_header" called without a parameter!'
-        exit 1
     fi
 }
 
 print_info ()
 {
+    if [ ! -z "$JSON_OUTPUT" ] ; then
+        print_info_json "$1" "$2"
+        return
+    fi
     if [ -z "$1" ] ; then
         echo 'Error: "print_info" is missing parameter(s)!'
         exit 1
@@ -39,8 +53,23 @@ print_info ()
     fi
 }
 
+print_info_json ()
+{
+    if [ -z "$1" ] ; then
+        echo 'Error: "print_info" is missing parameter(s)!'
+        exit 1
+    fi
+    #                                               escape \ (\ -> \\)     escape " (" -> \")         newline -> \n 
+    echo "    \"$(slugify "$1")\": \"$(echo "$2" | sed "s/['\\]/\\\&/g" | sed "s/['\"]/\\\&/g" | awk '{printf "%s\\n", $0}')\","
+}
+
 print_footer ()
 {
+    if [ ! -z "$JSON_OUTPUT" ] ; then
+        echo "  },"
+        return
+    fi
+
     printf "%0.s-" $(seq 1 $HORIZONTAL_LINE_WIDTH)
     printf "\n"
 }
@@ -253,6 +282,11 @@ check_root_user
 distro_detect
 devicetree_detect
 bootloader_detect
+if [ ! -z "$JSON_OUTPUT" ] ; then
+    echo "{"
+fi
+
+
 
 if [ $# -ne 0 ]; then
 
@@ -302,3 +336,7 @@ else
     software_summary
     hardware_info
 fi
+if [ ! -z "$JSON_OUTPUT" ] ; then
+    echo "}"
+fi
+

--- a/tdx-info
+++ b/tdx-info
@@ -347,6 +347,5 @@ else
     hardware_info
 fi
 if [ ! -z "$JSON_OUTPUT" ] ; then
-    echo "}"
+    printf "\n}\n"
 fi
-

--- a/tdx-info
+++ b/tdx-info
@@ -24,7 +24,7 @@ print_header ()
         if [ -n "$INSIDE_OBJECT" ] ; then
             printf ",\n"
         fi
-        echo "  \"$(slugify $1)\": {"
+        echo "  \"$(slugify "$1")\": {"
         INSIDE_OBJECT=1
         return
     fi
@@ -68,8 +68,8 @@ print_info_json ()
     fi
     INSIDE_OBJECT_2=1
 
-    #                                                escape \ (\ -> \\)     escape " (" -> \")         newline -> \n 
-    echo -n "    \"$(slugify "$1")\": \"$(echo "$2" | sed "s/['\\]/\\\&/g" | sed "s/['\"]/\\\&/g" | awk '{printf "%s\\n", $0}')\""
+    #                                                          \ -> \\)              " -> \"               newline -> \n
+    echo -n "    \"$(slugify "$1")\": \"$(echo -n "$2" | sed "s/['\\]/\\\&/g" | sed "s/['\"]/\\\&/g" | sed ':a;N;$!ba;s/\n/\\n/g')\""
 }
 
 print_footer ()


### PR DESCRIPTION
I didn't want to mess with the arg parsing, so I did this via environment variable.

This would potentially be useful if we want to upload this data to the platform in a (semi-)structured way.

Example output of `JSON_OUTPUT=1 tdx-info`:

```json
{
  "software": {
    "bootloader": "U-Boot",
    "kernel-version": "5.15.77-6.2.0-devel+git.2276f375f152 #1-TorizonCore SMP PREEMPT Mon Apr 3 13:46:31 UTC 2023",
    "kernel-command-line": "root=LABEL=otaroot rootfstype=ext4 quiet logo.nologo vt.global_cursor_default=0 plymouth.ignore-serial-consoles splash fbcon=map:3 ostree=/ostree/boot.0/torizon/8a048e8dcd63f44d9e7d1cf73385f003c2f36f89ea0a09cf246f3851e081a960/0",
    "distro-name": "NAME=\"TorizonCore\"",
    "distro-version": "VERSION_ID=6.2.0-devel-20230405-build.231",
    "hostname": "testdevice"  },
  "hardware": {
    "hw-model": "Toradex Apalis iMX8QM V1.1 on Apalis Evaluation Board",
    "toradex-version": "0037 V1.1B",
    "serial-number": "06804711",
    "processor-arch": "aarch64"  }
}
```

Example output of `JSON_OUTPUT=1 tdx-info -dt` (to show multi-line output in the JSON:

```json
{
  "device-tree": {
    "device-tree-enabled": "imx8qm-apalis-v1.1-eval.dtb",
    "compatible-string": "toradex,apalis-imx8-v1.1-evaltoradex,apalis-imx8-v1.1fsl,imx8qm",
    "device-trees-available": "imx8qm-apalis-eval.dtb\nimx8qm-apalis-ixora-v1.1.dtb\nimx8qm-apalis-v1.1-eval.dtb\nimx8qm-apalis-v1.1-ixora-v1.1.dtb\nimx8qm-apalis-v1.1-ixora-v1.2.dtb\nimx8qp-apalis-v1.1-eval.dtb\nimx8qp-apalis-v1.1-ixora-v1.1.dtb\nimx8qp-apalis-v1.1-ixora-v1.2.dtb"  },
  "device-tree-overlays": {
    "overlays-enabled": "fdt_overlays=apalis-imx8_hdmi_overlay.dtbo apalis-imx8_spi1_spidev_overlay.dtbo apalis-imx8_spi2_spidev_overlay.dtbo",
    "overlays-available": "apalis-imx8_ar0521_overlay.dtbo\napalis-imx8_hdmi_overlay.dtbo\napalis-imx8_mezzanine_can_overlay.dtbo\napalis-imx8_mezzanine_ov5640_overlay.dtbo\napalis-imx8_mezzanine_panel-cap-touch-10inch-lvds_overlay.dtbo\napalis-imx8_ov5640_overlay.dtbo\napalis-imx8_panel-cap-touch-10inch-lvds_overlay.dtbo\napalis-imx8_panel-lvds-dual-channel-1080p_overlay.dtbo\napalis-imx8_resistive-touch_overlay.dtbo\napalis-imx8_spi1_spidev_overlay.dtbo\napalis-imx8_spi2_spidev_overlay.dtbo"  }
}
```